### PR TITLE
fix: resolve fix wildcard token detection logic

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -67,7 +67,7 @@ func GetRootPath(path string, patternType PatternType, parentheses ParenthesesSl
 			continue
 		}
 		if patternType == RegExp {
-			if strings.Index(section, "((") != -1 {
+			if strings.Index(section, "(") != -1 {
 				break
 			}
 		} else {
@@ -81,7 +81,7 @@ func GetRootPath(path string, patternType PatternType, parentheses ParenthesesSl
 				}
 			}
 			if patternType == AntPattern {
-				if strings.Index(section, "?*") != -1 {
+				if strings.Index(section, "?") != -1 {
 					break
 				}
 			}


### PR DESCRIPTION
Automated fix for: **Fix wildcard token detection logic**

Changing detection from "(" to "((" (RegExp) and from "?" to "?*" (AntPattern) alters GetRootPath's stopping condition and can miss valid special-token boundaries, producing an incorrect (too-long) root path. The intent behind this behavior change is unclear (comment: "Why?").

---
_Generated by AI agent_