### PR TITLE
fix: resolve re-evaluate regexp root break condition

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -67,7 +67,8 @@ func GetRootPath(path string, patternType PatternType, parentheses ParenthesesSl
 			continue
 		}
 		if patternType == RegExp {
-			if strings.Index(section, "((") != -1 {
+			// Break once regex grouping is encountered to avoid miscomputing the root.
+			if strings.Contains(section, "(") {
 				break
 			}
 		} else {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -172,6 +172,22 @@ func TestIsWildcardParentheses(t *testing.T) {
 	}
 }
 
+func TestGetRootPath_RegExpBreakOnGrouping(t *testing.T) {
+	got := GetRootPath("foo/bar/(.*)/baz", RegExp, ParenthesesSlice{})
+	want := "foo/bar"
+	if got != want {
+		t.Errorf("GetRootPath(RegExp) == %s, want %s", got, want)
+	}
+}
+
+func TestGetRootPath_RegExpNoGroupingReturnsFullPath(t *testing.T) {
+	got := GetRootPath("foo/bar/baz", RegExp, ParenthesesSlice{})
+	want := "foo/bar/baz"
+	if got != want {
+		t.Errorf("GetRootPath(RegExp) == %s, want %s", got, want)
+	}
+}
+
 func TestAntPathToRegExp(t *testing.T) {
 	var fileSystemPaths []string = []string{
 		filepath.Join("dev", "a", "b.txt"),


### PR DESCRIPTION
Automated fix for: **Re-evaluate RegExp root break condition**

In GetRootPath for RegExp patterns, the break condition was changed from detecting any "(" to only detecting the substring "((". This likely changes behavior for common regexes containing single parentheses, potentially producing incorrect root paths by not breaking when grouping is present.

---
_Generated by AI agent_